### PR TITLE
fix: modi ALLOWED_HOSTS in settings.py

### DIFF
--- a/heechan/testProj/testProj/settings.py
+++ b/heechan/testProj/testProj/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 # AWS EC2 Instance 연결
 ALLOWED_HOSTS = [
-    ".ap-northeast-2.compute.amazonaws.com"
+    # ".ap-northeast-2.compute.amazonaws.com"
 ]
 
 


### PR DESCRIPTION
Modify to annotation the part of ALLOWED_HOSTS in settings.py, if not to annotation(amazonaws.com url), will occur error when you execute runserver instruction